### PR TITLE
Tests: Use forked pytest-splinter

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,3 +1,4 @@
 pytest==3.7.2
 pytest-cov==2.5.1
-pytest-splinter==1.9.1
+# pytest-splinter==1.9.1
+-e git+git://github.com/jsfehler/pytest-splinter.git@no_phantom_js#egg=pytest-splinter


### PR DESCRIPTION
The latest version of Splinter breaks pytest-splinter