### PR TITLE
Add RepeatingArea.areas.contain method

### DIFF
--- a/docs/area.rst
+++ b/docs/area.rst
@@ -23,6 +23,11 @@ The following Area objects are available:
   .. automethod:: stere.areas.RepeatingArea.area_with()
 
 
+.. autoclass:: stere.areas.Areas()
+
+  .. automethod:: stere.areas.Areas.contain()
+
+
 Reusing Areas
 -------------
 

--- a/stere/areas/__init__.py
+++ b/stere/areas/__init__.py
@@ -1,8 +1,9 @@
 from .area import Area
-from .repeating_area import RepeatingArea
+from .repeating_area import Areas, RepeatingArea
 
 
 __all__ = [
     'Area',
+    'Areas',
     'RepeatingArea',
 ]

--- a/stere/areas/repeating_area.py
+++ b/stere/areas/repeating_area.py
@@ -4,6 +4,57 @@ from .area import Area
 from ..fields import Field
 
 
+class Areas:
+    """Collection of Areas. Used by RepeatingArea.areas to store results.
+
+    Behaves like a list.
+    """
+    def __init__(self, container=None):
+        self._container = container or []
+
+    def __getattr__(self, item):
+        return getattr(self._container, item)
+
+    def __len__(self):
+        return len(self._container)
+
+    def __getitem__(self, item):
+        return self._container[item]
+
+    def contain(self, field_name, field_value):
+        """Check if a Field in any Area contains a specific value.
+
+        Arguments:
+            field_name (str): The name of the Field object.
+            field_value (str): The value of the Field object.
+
+        Returns:
+            bool: True if matching value found, else False
+
+        Example:
+
+            >>> class Inventory(Page):
+            >>>     def __init__(self):
+            >>>         self.items = RepeatingArea(
+            >>>             root=Root('xpath', '//div[@id='inventory']'),
+            >>>             description=Text('xpath', './td[1]')
+            >>>         )
+            >>>
+            >>> def test_stuff():
+            >>>     inventory = Inventory()
+            >>>     assert inventory.items.areas.contain(
+            >>>         "description", "Bananas")
+
+        """
+        for area in self:
+            field = getattr(area, field_name)
+
+            if field.value == field_value:
+                return True
+
+        return False
+
+
 class RepeatingArea:
     """
     Represents multiple identical Areas on a page.
@@ -22,7 +73,7 @@ class RepeatingArea:
     >>> from stere.areas import RepeatingArea
     >>> from stere.fields import Root, Link, Text
     >>>
-    >>> class Inventory():
+    >>> class Inventory(Page):
     >>>     def __init__(self):
     >>>         self.inventory_items = RepeatingArea(
     >>>             root=Root('xpath', '//table/tr'),
@@ -65,7 +116,7 @@ class RepeatingArea:
         then return a list of Areas: one for each root.
 
         Returns:
-            list: Collection of every Area that was found.
+            Areas: list-like collection of every Area that was found.
 
         Raises:
             ValueError: If no Areas were found.
@@ -77,7 +128,8 @@ class RepeatingArea:
             >>>     listings[0].my_input.fill('Hello world')
 
         """
-        created_areas = []
+        created_areas = Areas()
+
         all_roots = self.root.find_all()
         if 0 == len(all_roots):
             raise ValueError(
@@ -98,15 +150,15 @@ class RepeatingArea:
         matches the expected value and then returns the entire Area object.
 
         Arguments:
-            field_name (str): The name of the field object.
-            field_value (str): The value of the field object.
+            field_name (str): The name of the Field object.
+            field_value (str): The value of the Field object.
 
         Returns:
             Area
 
         Example:
 
-            >>> class Inventory():
+            >>> class Inventory(Page):
             >>>     def __init__(self):
             >>>         self.items = RepeatingArea(
             >>>             root=Root('xpath', '//my_xpath_string'),

--- a/stere/page.py
+++ b/stere/page.py
@@ -37,7 +37,7 @@ class Page(BrowserEnabled):
         `navigate()` method can be called.
 
         This method will call the method defined in `url_navigator`,
-        with `page_url`as the first parameter.
+        with `page_url` as the first parameter.
 
         In the following example, Stere is initialized with Splinter.
 
@@ -55,5 +55,6 @@ class Page(BrowserEnabled):
         >>>
         >>> home_page = Home()
         >>> home_page.navigate()
+
         """
         return getattr(self.browser, self.url_navigator)(self.page_url)

--- a/tests/splinter/test_repeating_area.py
+++ b/tests/splinter/test_repeating_area.py
@@ -10,6 +10,20 @@ from selenium.webdriver.remote.remote_connection import LOGGER
 LOGGER.setLevel(logging.WARNING)
 
 
+def test_areas_contain(test_page):
+    test_page.navigate()
+
+    assert test_page.repeating_area.areas.contain("link", "Repeating Link 1")
+
+
+def test_areas_contain_not_found(test_page):
+    test_page.navigate()
+
+    assert not test_page.repeating_area.areas.contain(
+        "link", "Repeating Link 666"
+    )
+
+
 def test_missing_root():
     expected_message = 'RepeatingArea requires a Root Field.'
 

--- a/tests/splinter/test_repeating_area.py
+++ b/tests/splinter/test_repeating_area.py
@@ -4,9 +4,9 @@ from pages import dummy_invalid
 
 import pytest
 
-from stere.areas import Areas
-
 from selenium.webdriver.remote.remote_connection import LOGGER
+
+from stere.areas import Areas
 
 
 LOGGER.setLevel(logging.WARNING)

--- a/tests/splinter/test_repeating_area.py
+++ b/tests/splinter/test_repeating_area.py
@@ -2,12 +2,20 @@ import logging
 
 from pages import dummy_invalid
 
+from stere.areas import Areas
+
 import pytest
 
 from selenium.webdriver.remote.remote_connection import LOGGER
 
 
 LOGGER.setLevel(logging.WARNING)
+
+
+def test_areas_len():
+    """Ensure Areas reports length correctly."""
+    a = Areas(['1', '2', '3'])
+    assert 3 == len(a)
 
 
 def test_areas_contain(test_page):

--- a/tests/splinter/test_repeating_area.py
+++ b/tests/splinter/test_repeating_area.py
@@ -20,7 +20,7 @@ def test_areas_contain_not_found(test_page):
     test_page.navigate()
 
     assert not test_page.repeating_area.areas.contain(
-        "link", "Repeating Link 666"
+        "link", "Repeating Link 666",
     )
 
 

--- a/tests/splinter/test_repeating_area.py
+++ b/tests/splinter/test_repeating_area.py
@@ -2,9 +2,9 @@ import logging
 
 from pages import dummy_invalid
 
-from stere.areas import Areas
-
 import pytest
+
+from stere.areas import Areas
 
 from selenium.webdriver.remote.remote_connection import LOGGER
 


### PR DESCRIPTION
- RepeatingArea.areas now returns a list-like object instead of a list.
- Fix typo in Page documentation